### PR TITLE
Read foreman if present

### DIFF
--- a/bin/launch_tracks
+++ b/bin/launch_tracks
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require "fileutils"
+require 'yaml'
 
 name = File.basename(FileUtils.pwd)
 label = "com.github.matsadler.launch_tracks.#{name}"
@@ -28,6 +29,10 @@ when "rm"
   FileUtils.rm(plist_path)
   exit
 when "setup"
+  file = File.join(FileUtils.pwd, '.foreman')
+  if !String.try_convert(port) && File.exists?(file)
+    port = YAML.load(File.read(file))['port'].to_s
+  end
   abort help unless port =~ /^\d+$/
   # continue
 else

--- a/bin/launch_tracks
+++ b/bin/launch_tracks
@@ -34,6 +34,7 @@ when "setup"
     port = YAML.load(File.read(file))['port'].to_s
   end
   abort help unless port =~ /^\d+$/
+  puts "Setting up on port:#{port}"
   # continue
 else
   abort help

--- a/bin/launch_tracks
+++ b/bin/launch_tracks
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require "fileutils"
 
-name = FileUtils.pwd.split("/").last
+name = File.basename(FileUtils.pwd)
 label = "com.github.matsadler.launch_tracks.#{name}"
 logdir = "/tmp"
 plist_name = "#{label}.plist"


### PR DESCRIPTION
Makes it even easier to setup for those projects which have a `.foreman` file present.

```
~/SomeProject$ launch_tracks setup
Setting up on port:3004
```

Does mean it needs `require 'yaml'`, I can parse the .foreman file without yaml if you dont want to extra dependancy.
